### PR TITLE
[CLOUD-82] Updating Base64 to use commons implementation

### DIFF
--- a/src/com/rusticisoftware/cheddargetter/client/CGService.java
+++ b/src/com/rusticisoftware/cheddargetter/client/CGService.java
@@ -30,6 +30,8 @@ package com.rusticisoftware.cheddargetter.client;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.apache.commons.codec.binary.Base64;
+
 import sun.misc.BASE64Encoder;
 
 import java.io.*;
@@ -508,7 +510,7 @@ public class CGService implements ICGService {
 		
 		try {
 			//Put authentication fields in http header, and make the data the body
-			BASE64Encoder enc = new BASE64Encoder();
+			Base64 enc = new Base64(0);
 			//connection.setRequestProperty("Content-Type", "text/xml");
 			String auth = userName + ":" + password;
 			connection.setRequestProperty("Authorization", "Basic " + enc.encode(auth.getBytes()));

--- a/src/com/rusticisoftware/cheddargetter/client/CGService.java
+++ b/src/com/rusticisoftware/cheddargetter/client/CGService.java
@@ -32,8 +32,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.apache.commons.codec.binary.Base64;
 
-import sun.misc.BASE64Encoder;
-
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;


### PR DESCRIPTION
This somewhat hard to test, but I think we have a good precedent of how to replace the base64 lib.